### PR TITLE
Remove stuff we don't care about

### DIFF
--- a/templates/default/35-server-per-host.conf.erb
+++ b/templates/default/35-server-per-host.conf.erb
@@ -10,48 +10,10 @@ $DirCreateMode 0755
 $FileGroup <%= node['rsyslog']['group'] %>
 
 $template PerHostAuth,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/auth.log"
-$template PerHostCron,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/cron.log"
 $template PerHostSyslog,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/syslog"
-$template PerHostDaemon,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/daemon.log"
-$template PerHostKern,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/kern.log"
-$template PerHostLpr,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/lpr.log"
-$template PerHostUser,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/user.log"
-$template PerHostMail,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/mail.log"
-$template PerHostMailInfo,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/mail.info"
-$template PerHostMailWarn,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/mail.warn"
-$template PerHostMailErr,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/mail.err"
-$template PerHostNewsCrit,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/news.crit"
-$template PerHostNewsErr,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/news.err"
-$template PerHostNewsNotice,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/news.notice"
-$template PerHostDebug,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/debug"
-$template PerHostMessages,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/messages"
 
 auth,authpriv.*         ?PerHostAuth
 *.*;auth,authpriv.none  -?PerHostSyslog
-cron.*                  ?PerHostCron
-daemon.*                -?PerHostDaemon
-kern.*                  -?PerHostKern
-lpr.*                   -?PerHostLpr
-mail.*                  -?PerHostMail
-user.*                  -?PerHostUser
-
-mail.info               -?PerHostMailInfo
-mail.warn               ?PerHostMailWarn
-mail.err                ?PerHostMailErr
-
-news.crit               ?PerHostNewsCrit
-news.err                ?PerHostNewsErr
-news.notice             -?PerHostNewsNotice
-
-*.=debug;\
-  auth,authpriv.none;\
-  news.none;mail.none   -?PerHostDebug
-
-*.=info;*.=notice;*.=warn;\
-  auth,authpriv.none;\
-  cron,daemon.none;\
-  mail,news.none        -?PerHostMessages
-
 
 <% unless node['rsyslog']['allow_non_local'] -%>
 #


### PR DESCRIPTION
In particular, `messages` is basically a copy of `syslog` but with less stuff in. But really it's all either in `syslog` or `auth.log` so I think it can all go.